### PR TITLE
Necessary changes needed for LoF project.

### DIFF
--- a/iot-ticket-client/CMakeLists.txt
+++ b/iot-ticket-client/CMakeLists.txt
@@ -68,7 +68,7 @@ if(BUILD_DEMO)
 endif()
 
     
-install(FILES ${JSONCPP_HDRS} DESTINATION include/IOT_API/json)
+install(FILES ${JSONCPP_HDRS} DESTINATION include/json)
 install(FILES ${IOTAPI_HEADERS} DESTINATION include/IOT_API)
 
 configure_file(FindIOT_API.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/FindIOT_API.cmake @ONLY)

--- a/iot-ticket-client/CMakeLists.txt
+++ b/iot-ticket-client/CMakeLists.txt
@@ -14,7 +14,6 @@ INCLUDE_DIRECTORIES(
 )
 
 set(IOTAPI_HEADERS 
-    ${JSONCPP_HDRS}
     IOT_WriteData.h
     IOT_ReadData.h
     IOT_ReadDataFilter.h
@@ -68,7 +67,8 @@ if(BUILD_DEMO)
         ARCHIVE DESTINATION lib)
 endif()
 
-
+    
+install(FILES ${JSONCPP_HDRS} DESTINATION include/IOT_API/json)
 install(FILES ${IOTAPI_HEADERS} DESTINATION include/IOT_API)
 
 configure_file(FindIOT_API.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/FindIOT_API.cmake @ONLY)

--- a/iot-ticket-client/jsoncpp/json/json.h
+++ b/iot-ticket-client/jsoncpp/json/json.h
@@ -68,7 +68,6 @@ license you like.
 // End of content of file: LICENSE
 // //////////////////////////////////////////////////////////////////////
 
-
 #ifndef JSON_AMALGATED_H_INCLUDED
 # define JSON_AMALGATED_H_INCLUDED
 /// If defined, indicates that the source file is amalgated
@@ -112,7 +111,7 @@ license you like.
 /// If defined, indicates that the source file is amalgated
 /// to prevent private header inclusion.
 /// Remarks: it is automatically defined in the generated amalgated header.
-// #define JSON_IS_AMALGAMATION
+#define JSON_IS_AMALGAMATION 1
 
 
 # ifdef JSON_IN_CPPTL


### PR DESCRIPTION
Changes include defining amalmagation to prevent private header inclusion and fix to the include folder paths so that external cmake projects can be built.
