### PR TITLE
Stringstream error and missing link to library pthread

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ This project does not build the libcurl and it needs to be installed before buil
 The library project uses CMake. To build the library for the host system, following commands can be issued from the project root directory:
 ```sh
 $ cmake iot-ticket-client
-$ make 
+$ make
 ```
 
 These commands build the shared library. Additionally tests and a demo application can be built. The tests and demo application use features from C++11 standard which needs to be enabled by providing a compiler flag. For older compilers the correct flag might be "-std=c\+\+0x"
 ```sh
-$ cmake -DBUILD_TESTS=1 -DBUILD_DEMO=1 -DCMAKE_CXX_FLAGS="-std=c++11" iot-ticket-client
-$ make 
+$ cmake -DBUILD_TESTS=1 -DBUILD_DEMO=1 -DCMAKE_CXX_FLAGS="-std=c++11 -lpthread" iot-ticket-client
+$ make
 ```
 
 ### Example code

--- a/iot-ticket-client/IOT_ReadData.cpp
+++ b/iot-ticket-client/IOT_ReadData.cpp
@@ -78,7 +78,7 @@ bool IOT_ReadData::GetConvertedValue(size_t index, long& value) const
     std::stringstream ss(m_processData.at(index).second);
     ss >> value;
 
-    return ss;
+    return value;
 }
 
 bool IOT_ReadData::GetConvertedValue(size_t index, double& value) const
@@ -89,7 +89,7 @@ bool IOT_ReadData::GetConvertedValue(size_t index, double& value) const
     std::stringstream ss(m_processData.at(index).second);
     ss >> value;
 
-    return ss;
+    return value;
 }
 
 bool IOT_ReadData::GetConvertedValue(size_t index, bool& value) const


### PR DESCRIPTION
cannot convert ‘std::stringstream’ {aka ‘std::__cxx11::basic_stringstream<char>’} to ‘bool’ in return

/usr/bin/ld: CMakeFiles/iot-ticket-tests.dir/tests/IOT_Tester.cpp.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/usr/bin/ld: /usr/lib/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
